### PR TITLE
Fix for multi operations not calling the callback if all servers are disconnected.

### DIFF
--- a/lib/remcached.rb
+++ b/lib/remcached.rb
@@ -110,6 +110,11 @@ module Memcached
         end
       end
 
+      if client_contents.empty?
+        callback.call results
+        return self
+      end
+
       # send requests and wait for responses per client
       clients_pending = client_contents.length
       client_contents.each do |client,contents_list|

--- a/spec/memcached_spec.rb
+++ b/spec/memcached_spec.rb
@@ -1,5 +1,6 @@
 $: << File.dirname(__FILE__) + '/../lib'
 require 'remcached'
+require 'em-spec/rspec'
 
 describe Memcached do
   def run(&block)
@@ -261,6 +262,20 @@ describe Memcached do
         }
         @results.should be_empty
         @calls.should == 1
+      end
+    end
+
+    context "when servers are disconnected" do
+      include EM::SpecHelper
+
+      it "should return immediately with response" do
+        em(1) do
+          keys = [ { :key => key(0) } ]
+          Memcached.multi_get(keys) { |responses|
+            responses[key(0)][:status].should == Memcached::Errors::DISCONNECTED
+            stop
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
If a multi_\* operation is performed whilst all servers are disconnected, the callback is never fired.

This attempts to fix the issue by calling the callback with the results in such a circumstance.
